### PR TITLE
neopixel: increase BIT_MAX_TIME to increase compatibility on AVR

### DIFF
--- a/klippy/extras/neopixel.py
+++ b/klippy/extras/neopixel.py
@@ -7,7 +7,7 @@ import logging
 
 BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
 
-BIT_MAX_TIME=.000004
+BIT_MAX_TIME=.000030
 RESET_MIN_TIME=.000050
 
 MAX_MCU_SIZE = 500  # Sanity check on LED chain length


### PR DESCRIPTION
It appears that LED strips are more permissive about bit time.
This makes use of that to actually make it possible to support
LED strips on AVR. Without that, the bit time is too short
due to hardware irq (on timer) being fired and return early
from neopixel update.

Signed-off-by: Kamil Trzcinski <ayufan@ayufan.eu>